### PR TITLE
Align pages with glassmorphism design tokens and normalize navigation

### DIFF
--- a/articles/mining-pool-latency-guide.html
+++ b/articles/mining-pool-latency-guide.html
@@ -58,11 +58,13 @@
 
 
         .highlight-box {
-            background: rgba(255, 255, 255, 0.05);
-            border-left: 4px solid var(--accent-primary);
-            padding: 1.5rem;
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-left: 4px solid var(--accent-color);
+            padding: 1.75rem;
             margin: 2rem 0;
-            border-radius: 0 8px 8px 0;
+            border-radius: 12px;
+            backdrop-filter: blur(12px);
         }
 
         @media (max-width: 768px) {
@@ -87,6 +89,10 @@
 
 <body>
     <div class="bg-gradient"></div>
+    <div class="bg-blobs">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
     <main class="container article-content">
         <a href="../index.html" class="back-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -94,7 +100,7 @@
                 <line x1="19" y1="12" x2="5" y2="12"></line>
                 <polyline points="12 19 5 12 12 5"></polyline>
             </svg>
-            Back to Lab
+            back to lab
         </a>
 
         <header>

--- a/articles/smart-stratum-proxies.html
+++ b/articles/smart-stratum-proxies.html
@@ -51,36 +51,19 @@
 
 
         .contact-card {
-            background: rgba(88, 166, 255, 0.05);
-            border: 1px solid rgba(88, 166, 255, 0.2);
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
             padding: 3rem;
             border-radius: 16px;
             text-align: center;
             margin-top: 4rem;
+            backdrop-filter: blur(12px);
         }
 
         .contact-card h3 {
             color: #fff;
             margin-bottom: 1rem;
             font-size: 1.8rem;
-        }
-
-        .btn-contact {
-            display: inline-block;
-            background: var(--accent-color);
-            color: #000;
-            padding: 1rem 2.5rem;
-            border-radius: 8px;
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 1.1rem;
-            margin-top: 1.5rem;
-            transition: transform 0.2s, background 0.2s;
-        }
-
-        .btn-contact:hover {
-            transform: translateY(-2px);
-            background: #fff;
         }
 
         @media (max-width: 768px) {
@@ -109,6 +92,10 @@
 
 <body>
     <div class="bg-gradient"></div>
+    <div class="bg-blobs">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
     <main class="container article-content">
         <a href="../index.html" class="back-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -116,7 +103,7 @@
                 <line x1="19" y1="12" x2="5" y2="12"></line>
                 <polyline points="12 19 5 12 12 5"></polyline>
             </svg>
-            Back to Lab
+            back to lab
         </a>
 
         <header>
@@ -160,7 +147,7 @@
                     Please write a few lines about your setup if you're interested in getting access.
                 </p>
                 <a href="mailto:merc1305@gmail.com?subject=Inquiry about Stratum Proxy Access"
-                    class="btn-contact">Contact via Email</a>
+                    class="btn btn-primary">Contact via Email</a>
             </div>
         </section>
     </main>

--- a/articles/stratum-latency-methodology.html
+++ b/articles/stratum-latency-methodology.html
@@ -73,6 +73,10 @@
 
 <body>
     <div class="bg-gradient"></div>
+    <div class="bg-blobs">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
     <main class="container article-content">
         <a href="../index.html" class="back-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -80,7 +84,7 @@
                 <line x1="19" y1="12" x2="5" y2="12"></line>
                 <polyline points="12 19 5 12 12 5"></polyline>
             </svg>
-            Back to Lab
+            back to lab
         </a>
 
         <header>

--- a/business-conspect/index.html
+++ b/business-conspect/index.html
@@ -132,7 +132,7 @@
         <line x1="19" y1="12" x2="5" y2="12"></line>
         <polyline points="12 19 5 12 12 5"></polyline>
       </svg>
-      Back to Lab
+      back to lab
     </a>
 
     <!-- Hero Section -->

--- a/mining-stratum/index.html
+++ b/mining-stratum/index.html
@@ -137,13 +137,14 @@
         }
 
         .info-box {
-            background: rgba(88, 166, 255, 0.05);
-            border: 1px solid rgba(88, 166, 255, 0.2);
-            padding: 1rem;
-            border-radius: 8px;
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            padding: 1rem 1.25rem;
+            border-radius: 12px;
             margin-bottom: 2rem;
             font-size: 0.9rem;
             color: var(--text-primary);
+            backdrop-filter: blur(12px);
         }
 
         .grid {
@@ -434,20 +435,22 @@
         }
 
         .warning-box {
-            background: rgba(248, 81, 73, 0.05);
-            border: 1px solid rgba(248, 81, 73, 0.2);
+            background: var(--glass-bg);
+            border: 1px solid rgba(248, 81, 73, 0.35);
             padding: 1.5rem;
-            border-radius: 8px;
+            border-radius: 12px;
             margin: 2rem 0;
             color: var(--text-primary);
+            backdrop-filter: blur(12px);
         }
 
         .tool-intro {
             margin-bottom: 2.5rem;
             padding: 1.5rem;
-            background: rgba(88, 166, 255, 0.03);
+            background: var(--glass-bg);
             border-radius: 12px;
-            border: 1px dashed rgba(88, 166, 255, 0.1);
+            border: 1px dashed var(--glass-border);
+            backdrop-filter: blur(12px);
         }
 
         .tool-intro p {
@@ -457,11 +460,12 @@
         }
 
         .tldr {
-            background: rgba(63, 185, 80, 0.05);
-            border: 1px solid rgba(63, 185, 80, 0.2);
+            background: var(--glass-bg);
+            border: 1px solid rgba(63, 185, 80, 0.35);
             padding: 1.5rem;
             border-radius: 12px;
             margin-bottom: 2rem;
+            backdrop-filter: blur(12px);
         }
 
         .tldr h4 {
@@ -542,7 +546,7 @@
                     <line x1="19" y1="12" x2="5" y2="12"></line>
                     <polyline points="12 19 5 12 12 5"></polyline>
                 </svg>
-                Back to Lab
+                back to lab
             </a>
             <h1>
                 <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
@@ -580,8 +584,7 @@
         </div>
 
         <section class="content-section" style="margin-top: 2rem; border-top: none; padding-top: 0;">
-            <div class="glass-card"
-                style="background: rgba(88, 166, 255, 0.05); border: 1px solid rgba(88, 166, 255, 0.1); padding: 2rem; border-radius: 12px;">
+            <div class="glass-card" style="padding: 2rem; border-radius: 12px;">
                 <h2
                     style="color: var(--accent-color); margin-bottom: 1.5rem; display: flex; align-items: center; gap: 10px;">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"


### PR DESCRIPTION
### Motivation
- Unify page visuals with the project's glassmorphism design tokens and component patterns for consistent cards, callouts, and navigation text across tools and articles.
- Replace scattered ad-hoc RGBA styles and page-specific button rules with centralized tokens to reduce divergence and simplify maintenance.
- Ensure articles include the shared decorative background blobs to match site-wide layout aesthetics.

### Description
- Replaced per-page RGBA callout/card styles with `--glass-bg` and `--glass-border`, added `backdrop-filter: blur(12px)`, increased border radii, and adjusted padding in `mining-stratum/index.html` and article pages to follow the glass-card pattern.
- Normalized the back-link label to `back to lab` across `mining-stratum/index.html`, `business-conspect/index.html`, and the article pages to keep navigation wording consistent.
- Added the shared `bg-blobs` markup to article pages (`articles/*.html`) so they include the decorative blobs used site-wide.
- Removed the page-specific `.btn-contact` rules and switched the contact link to the shared `.btn.btn-primary` class in `articles/smart-stratum-proxies.html` and simplified an inline `glass-card` to rely on the shared styles.

### Testing
- Started a local server with `python -m http.server 8000` which ran successfully.
- Captured full-page screenshots with a Playwright script for `mining-stratum` and `business-conspect` producing artifacts `artifacts/mining-stratum.png` and `artifacts/business-conspect.png` successfully.
- Committed the changes to the working branch which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697643d58a188329ad1d576ca905d0e3)